### PR TITLE
Correción en validación de nombres

### DIFF
--- a/Cliente.ts
+++ b/Cliente.ts
@@ -32,4 +32,18 @@ export class Cliente extends Persona {
 			this.visitas = visitas;
 		}
 	}
+
+	// Establece el nombre del cliente. Extiende el método original de Entidad para 
+	// no permitir números
+	public setNombre(nombre: string): void {
+		super.setNombre(nombre);
+
+		// Verificar si el nombre tiene números
+		if (nombre.match(/\d/)) {
+			//busca cualquier numero en el nombre
+			throw new Error(
+				`${nombre} Nombre inválido: El nombre no puede ser un número o contener números.`
+			);
+		}
+	}
 }

--- a/Entidad.ts
+++ b/Entidad.ts
@@ -1,5 +1,4 @@
 // Interfaz 'IEntidad' para definir la estructura de una entidad
-import { parse } from "path";
 import { IEntidad } from "./IEntidad";
 
 import * as rls from "readline-sync"; // Para entrada de datos en consola
@@ -16,34 +15,7 @@ export class Entidad implements IEntidad {
 	constructor(id: number, nombre: string) {
 		// Validar si el id es indefinido o es menor a un caracter
 		if (id == undefined || id < 1) throw Error(`ID inválido (id: ${id}`);
-
-		// Validar que el nombre no este vacío
-		if (!nombre) {
-			throw new Error(`Nombre inválido: El nombre no puede estar vacío.`);
-		}
-
-		// Validar si el nombre no es una cadena
-		if (typeof nombre !== "string") {
-			throw new Error(
-				`${nombre} Nombre inválido: El nombre debe ser una cadena de texto.`
-			);
-		}
-
-		// Verificar si el nombre tiene números
-		if (nombre.match(/\d/)) {
-			//busca cualquier numero en el nombre
-			throw new Error(
-				`${nombre} Nombre inválido: El nombre no puede ser un número o contener números.`
-			);
-		}
-
-		// Validar si el nombre tiene menos de 3 caracteres
-		if (nombre.length < 3) {
-			throw new Error(
-				`${nombre} Nombre inválido: El nombre  debe tener al menos 3 caracteres.`
-			);
-		}
-
+		
 		this.id = id;
 		this.setNombre(nombre);
 	}
@@ -60,9 +32,19 @@ export class Entidad implements IEntidad {
 
 	// Establece el nombre de la entidad
 	public setNombre(nombre: string): void {
-		if (nombre == undefined || nombre.length < 1) {
+		
+		//Valida que no se pase un string indefinido
+		if (nombre == undefined) {
 			throw Error(`Nombre inválido (nombre: '${nombre}')`);
 		}
+
+		// Validar si el nombre tiene menos de 3 caracteres
+		if (nombre.length < 3) {
+			throw new Error(
+				`Nombre inválido: El nombre  debe tener al menos 3 caracteres. (Nombre: '${nombre}')`
+			);
+		}
+
 		this.nombre = nombre;
 	}
 


### PR DESCRIPTION
En Entidad.ts

1. Removí la validación de nombres del constructor de la Entidad y lo pase al setter. De está manera solo se valida una vez si en el contructor llamamos a los setters
2. Cambie el !nombre por nombre==undefined (Por algún motivo Mauricio lo hacía siempre así)
3. No es necesario chequear con typeof el tipo de un parámetro. Typescript no te va a permitir que le pases un tipo diferente (Y recuerdo que Mauricio mencionó en alguna clase que no se debería usar typeof())
4. La válidación de números en el nombre la removí pero la pase a la clase cliente

En Cliente.ts

1. Extendí el método setNombre para incluir la validación de que no haya números solo en la clase cliente. Noten que la primera línea de setNombre llama al setNombre original con super de esa manera no hay que hacer todo el método de nuevo.
